### PR TITLE
docs: translate badges back into english

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
 	<h1 align="center">Notions</h1>
 	<p align="center">
-		<img alt="GitHub last commit (branch)" src="https://img.shields.io/github/last-commit/readthedocs-fr/notions/master?label=derni%C3%A8re%20mise%20%C3%A0%20jour&style=flat-square">
+		<img alt="GitHub last commit (branch)" src="https://img.shields.io/github/last-commit/readthedocs-fr/notions/master?label=last%20update&style=flat-square">
 		<img alt="GitHub contributors" src="https://img.shields.io/github/contributors/readthedocs-fr/notions?color=blue&style=flat-square">
 	</p>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
 	<h1 align="center">Notions</h1>
 	<p align="center">
-		<img alt="Date du dernier commit sur la branche master" src="https://img.shields.io/github/last-commit/readthedocs-fr/notions/master?label=derni%C3%A8re%20mise%20%C3%A0%20jour&style=flat-square">
-		<img alt="Nombre de contributeurs" src="https://img.shields.io/github/contributors/readthedocs-fr/notions?color=blue&label=contributeurs&style=flat-square">
+		<img alt="GitHub last commit (branch)" src="https://img.shields.io/github/last-commit/readthedocs-fr/notions/master?label=derni%C3%A8re%20mise%20%C3%A0%20jour&style=flat-square">
+		<img alt="GitHub contributors" src="https://img.shields.io/github/contributors/readthedocs-fr/notions?color=blue&style=flat-square">
 	</p>
 </p>
 


### PR DESCRIPTION
En mettant les labels des badges en anglais, on rend ces derniers cohérents avec les données qu'ils affichent à leur droite.
Le badge de dernière mise à jour affiche un jour, un mois en anglais, le badge du nombre de contributeurs affiche un nombre, cependant vu qu'il est plus cohérent de laisser le badge de dernière mise à jour en anglais, il faut aussi le mettre en anglais pour que le tout soit cohérent.