### PR TITLE
feat(python/starter-kit): add english translation

### DIFF
--- a/python/starter_kit/README.md
+++ b/python/starter_kit/README.md
@@ -13,6 +13,7 @@ Dans cette fiche, nous allons voir quelles sont les étapes pour bien démarrer 
 # Starting well with Python
 
 > Originally written by [TNtube](https://github.com/TNtube)
+
 > English translation by [FuseTim](https://github.com/fusetim)
 
 You make your first steps in the programming world?

--- a/python/starter_kit/README.md
+++ b/python/starter_kit/README.md
@@ -12,13 +12,13 @@ Dans cette fiche, nous allons voir quelles sont les étapes pour bien démarrer 
 
 # Starting well with Python
 
-> Originally written by [TNtube](https://github.com/TNtube)
+> Original article authored by [TNtube](https://github.com/TNtube)
 
-> English translation by [FuseTim](https://github.com/fusetim)
+> Translation authored by [FuseTim](https://github.com/fusetim)
 
 You make your first steps in the programming world?
 You wish to begin with a simple and intuitive language such as Python?
-In this sheet, we gonna see what are the steps to well begin in the vast and interesting world that is the programming in Python.
+In this sheet, we are going to see what are the steps to well begin in the vast and interesting world that is the programming in Python.
 
 ## Table of Contents
 - [How to well begin with Python](en/START_WELL.md)

--- a/python/starter_kit/README.md
+++ b/python/starter_kit/README.md
@@ -10,15 +10,15 @@ Dans cette fiche, nous allons voir quelles sont les étapes pour bien démarrer 
 - [Comment bien commencer avec python](fr/START_WELL.md)
 
 
-# Starting well with Python
+# Starting off right with Python
 
 > Original article authored by [TNtube](https://github.com/TNtube)
 
 > Translation authored by [FuseTim](https://github.com/fusetim)
 
-You make your first steps in the programming world?
+You are making your first steps in the programming world?
 You wish to begin with a simple and intuitive language such as Python?
-In this sheet, we are going to see what are the steps to well begin in the vast and interesting world that is the programming in Python.
+In this article, we are going to see what you should do first to be off a good start in the vast and interesting world that's the programming in Python.
 
-## Table of Contents
-- [How to well begin with Python](en/START_WELL.md)
+## Table of contents
+- [Starting off right with Python](en/START_WELL.md)

--- a/python/starter_kit/README.md
+++ b/python/starter_kit/README.md
@@ -10,7 +10,7 @@ Dans cette fiche, nous allons voir quelles sont les étapes pour bien démarrer 
 - [Comment bien commencer avec python](fr/START_WELL.md)
 
 
-# Starting off right with Python
+# Starting Off Right with Python
 
 > Original article authored by [TNtube](https://github.com/TNtube)
 
@@ -18,7 +18,7 @@ Dans cette fiche, nous allons voir quelles sont les étapes pour bien démarrer 
 
 You are making your first steps in the programming world?
 You wish to begin with a simple and intuitive language such as Python?
-In this article, we are going to see what you should do first to be off a good start in the vast and interesting world that's the programming in Python.
+In this article, we are going to see what you should do first to be off a good start in the vast and interesting world that's Python programming.
 
-## Table of contents
-- [Starting off right with Python](en/START_WELL.md)
+## Table of Contents
+- [Starting Off Right with Python](en/START_WELL.md)

--- a/python/starter_kit/README.md
+++ b/python/starter_kit/README.md
@@ -8,3 +8,16 @@ Dans cette fiche, nous allons voir quelles sont les étapes pour bien démarrer 
 ## Table des matières
 
 - [Comment bien commencer avec python](fr/START_WELL.md)
+
+
+# Starting well with Python
+
+> Originally written by [TNtube](https://github.com/TNtube)
+> English translation by [FuseTim](https://github.com/fusetim)
+
+You make your first steps in the programming world?
+You wish to begin with a simple and intuitive language such as Python?
+In this sheet, we gonna see what are the steps to well begin in the vast and interesting world that is the programming in Python.
+
+## Table of Contents
+- [How to well begin with Python](en/START_WELL.md)

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -27,10 +27,10 @@ such as the course of **[ TODO ]**.
 ### Errors to not do when you begin
 
 Many people begin programming with the idea that is not necessary complicated,
-and we can quickly make very big projects without the need to aquire all the bases.
+and they can quickly make very big projects without the need to aquire all the bases.
 Well, that is mostly a big mistake.
 
-In fact, learn a language whether it is Python or another, need to be done carefully.
+In fact, learn a language whether it is Python or another, needs to be done carefully.
 You should not try to drive a car without learn to do it. Thus, a lot of beginners 
 in Python launch themselves in libraries too much advanced for them, like `Pygame`, `Tkinter` or such as `discord.py`
 that need advanced notions such as the Oriented Object Programming, the error handling,
@@ -49,14 +49,14 @@ programming in general (that would be counterproductive).
 What is better to begin with programming more than give yourself objectives. Have a project
 is a very great way to learn. Indeed, after seeing the theory in courses,
 begin a project, permits to practice. Practicing is the only way that permits to remember durably.
-Thus, we can begin small and adapted projects to what we learn.
+Thus, we can begin small and adapted projects to what we learned.
 
 Here are some examples:
 - A fair price game after seeing loops and conditions ;
 - A hangman, when you master the treatment of character strings ;
 - A tic-tac-toe in shell, pretty fun and instructive to assimilate the loops.
 
-Once the basis mastered, do not hesitate to be curious. Relying on your knowledge do not permits to evolve.
+Once the basis mastered, do not hesitate to be curious. Relying on your knowledge does not permit to evolve.
 There are always things to learn, to experiment or to discover.
 
 ### Conclusion

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -1,67 +1,67 @@
-# Starting well with Python
+# Starting off right with Python
 
-Programming is a domain very interesting, lucrative and vast.
-Begin with Python is really often a judicious choice for many reasons.
+Programming is a very interesting, lucrative and vast domain.
+Choosing Python as a first language is really often a judicious choice for many reasons.
 
 Here are some of them:
-- Python has a very simple syntax, that permits to get compact and lisible codes ;
+- Python has a very simple syntax, that permits to get compact and readable codes ;
 - Python is very complete. Concretely, we can do a huge amount of things with it.
-From AI, throught the Web backend, to its utilization in the scientific domains ;
+From AI, to the Web backend, to its usage in scientific domains... the list goes on ;
 - The language has a huge community of developers with a lot of resources,
- and some of its functionalities make learning easy for the beginners.
-(for some reasons hard to explain here, but for instance, the language does not enforce the usage of `;` after each expression).
+ and some of its functionalities make the learning process easier for beginners.
+One example is that the language does not enforce the usage of `;` after each instruction.
 
 
-### Some good resources to learn well
+### Some good resources to get started
 
-> On the Internet, lots of tutorials/courses to learn development exist, except many
-> of them are bad because they teach you bad practices or 
-> obsolete things. - [learndev.info](https://www.learndev.info/en)
+> On the Internet, lots of tutorials/courses to learn development exist, except that many
+> of them are bad because they teach you bad obsolete practices. - [learndev.info](https://www.learndev.info/en)
 
-Indeed, the resources available on the Internet are not always relevant or up-to-date.
-That is why, the website [learndev.info](https://www.learndev.info/en) offers adapted and relevant courses,
+
+In fact, the resources available on the Internet are not always relevant or up-to-date.
+As a solution to solve this issue [learndev.info](https://www.learndev.info/en) was created, aiming to offer adapted and relevant courses,
 such as the course of **[ TODO ]**.
 
 
 
-### Errors to not do when you begin
+### Mistakes not to do when you begin
 
-Many people begin programming with the idea that is not necessary complicated,
-and they can quickly make very big projects without the need to aquire all the bases.
+Many people begin programming with the idea that it is not necessarily complicated,
+and they can quickly start very big projects without the need to acquire the bases.
 Well, that is mostly a big mistake.
 
-In fact, learn a language whether it is Python or another, needs to be done carefully.
-You should not try to drive a car without learn to do it. Thus, a lot of beginners 
-in Python launch themselves in libraries too much advanced for them, like `Pygame`, `Tkinter` or such as `discord.py`
-that need advanced notions such as the Oriented Object Programming, the error handling,
-decorators or even the manipulation of threads/async.
+In fact, when it comes to learning a language (whether it is Python or another), things need to be done carefully.
+You should not try to drive a car before learning to do it. And yet, unfortunately a lot of
+Python beginners get to work with libraries that are way too much complicated for them, like
+`Pygame`, `Tkinter` or such as `discord.py` and whose usage require notions such as the 
+Object Oriented Programming, error handling, decorators or even manipulation of threads/async.
 
-If you do not know what is a function, an object or manipulate loops likes `for` and `while` loops,
-you have everything to gain to let your project on a side for a time to consolidate your knowledge and even, make
+If you do not know what a function or an object is, or can not manipulate `for` and `while` loops,
+you had better put your project aside for a time to consolidate your knowledge and even, make
 projects at your scale in order to accumulate knowledge for the one that is close to your heart.
-Do not be afraid to let a project during several months.
-Accumulate frustration by continuously failling on a too ambicious project can disgust you with
-programming in general (that would be counterproductive).
+Do not be afraid to let aside a project for several months.
+Accumulating frustration by continuously failing on a too ambitious project can disgust you 
+with programming in general (that would be counterproductive).
 
 
 ### Projects, lots of projects, more projects!
 
-What is better to begin with programming more than give yourself objectives. Have a project
-is a very great way to learn. Indeed, after seeing the theory in courses,
-begin a project, permits to practice. Practicing is the only way that permits to remember durably.
-Thus, we can begin small and adapted projects to what we learned.
+Nothing beats starting programming by giving yourself objectives. Having a project
+is a great way to learn. After seeing the theory in courses,
+beginning a project allows you to practice. Practicing is the only way that permits to remember in the long run.
+Therefore, you should definitely find projects adapted to what you are currently learning.
 
 Here are some examples:
 - A fair price game after seeing loops and conditions ;
 - A hangman, when you master the treatment of character strings ;
 - A tic-tac-toe in shell, pretty fun and instructive to assimilate the loops.
 
-Once the basis mastered, do not hesitate to be curious. Relying on your knowledge does not permit to evolve.
+Once the basis mastered, do not hesitate to be curious. Relying on your knowledge only does not permit you to improve.
 There are always things to learn, to experiment or to discover.
 
 ### Conclusion
 
-Python is a really good language to begin in the programming world. Moreover to be easy to learn,
-it permits a huge amount of things. Dispite the fact, it is necessary to practice with the help of projects,
+Python is a really good language if you are a rookie in the programming world. Not only it is easy to learn,
+but also it allows you to do a huge amount of things. Despite the fact that it is necessary to practice by workinng on projects,
 it is very discouraged to begin with something too big for yourself.
-Finally, if there is only one sentence to remember from that, it would be this one: "Never stop learning".
+Finally, if there were only one sentence to remember from all this, it would be this one: "Never stop learning".

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -20,7 +20,7 @@ One example is that the language does not enforce the usage of `;` after each in
 
 In fact, the resources available on the Internet are not always relevant or up-to-date.
 As a solution to solve this issue, [learndev.info](https://www.learndev.info/en) was created, aiming to offer adapted and relevant courses,
-such as the course of **[ TODO ]**.
+such as the course from [JetBrains Academy](https://hyperskill.org/onboarding/tracks/2).
 
 
 

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -1,0 +1,67 @@
+# Starting well with Python
+
+Programming is a domain wery interesting, lucrative and vast.
+Begin with Python is really often a judicious choice for many reasons.
+
+Here are some of them:
+- Python has a very simple syntax, that permits to get compact and lisible codes ;
+- Python is very complete. Concretely, we can do a huge amount of things with it.
+From AI, throught the Web backend, to its utilisation in the scientific domains. ;
+- The language has a huge community of developers with a lot of resources,
+ and some of its functionalities make learning easy for the beginners.
+(for some reasons hard to explain here, but for instance, the language does not enforce the usage of `;` after each expression).
+
+
+### Some good resources to learn well
+
+> On the Internet, lots of tutorials/courses to learn development exist, except many
+> of them are bad because they teach you bad practices or 
+> obsolete things. - [learndev.info](https://www.learndev.info/en)
+
+Indeed, the resources available on the Internet are not always relevant or up-to-date.
+That is why, the website [learndev.info](https://www.learndev.info/en) offers adapted and relevant courses,
+such as the course of **[ TODO ]**.
+
+
+
+### What not to do when you begin
+
+Many people begin programming with the idea that is not necessary complicated,
+and we can quickly make very big projects without the need to aquire all the bases.
+Well, that is mostly a big mistake.
+
+In fact, learn a language whether it is Python or another, need to be done carefully.
+You should not try to drive a car without learn to do it. Thus, a lot of beginners 
+in Python launches themselves in libraries too much advanced for them, like `Pygame`, `Tkinter` or such as `discord.py`
+that need advanced notions such as the Oriented Object Programming, the error handling,
+decorators or even the mannipulation of threads/async.
+
+If you do not know what is a function, an object or manipulate loops likes `for` and  `while` loops,
+you have everything to gain to let your project on a side for the time to consolidate your knowledges and even make
+projects at your scale in order to accumulate knowledges for the one that is close to your heart.
+Do not be affraid to let a project during several monthes.
+Accumulate frustration by continuously failling on a too ambicious project can disgust you with
+programming in genneral (that will be counterproductive).
+
+
+### Projects, lots of projects, more projects!
+
+What is better to begin with programming more than give themself objectives. Have a project
+is a very great way to learn. Indeed, after seeing the theory in courses,
+begin a project, permits to practice. Practicing is the only way that permits to remember durably.
+Thus, we can begin small and adapted projects to what we learn.
+
+Here are some examples:
+- A fair price game after seeing loops and conditions ;
+- A hangman, when you master the treatment of character strings ;
+- A tic-tac-toe in shell, pretty fun and instructive to assimilate the loops.
+
+Once the basis mastered, do not hesitate to be curious. Relying on your knowledge do not permits to evolve.
+There are always things to learn, to experiment or to discover.
+
+### Conclusion
+
+Python is a really good language to bgin in the programming world. Moreover to be easy to learn,
+it permits a huge amount of things. Dispite the fact, it is necessary to practice with the help of projects,
+it is very discouraged to begin with something too big for yourserf.
+Finally, if there is only one sentence to remember from that, it would be this one: "Do not stop to learn".

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -33,7 +33,7 @@ Well, that is mostly a big mistake.
 In fact, when it comes to learning a language (whether it is Python or another), things need to be done carefully.
 You should not try to drive a car before learning to do it. And yet, unfortunately a lot of
 Python beginners get to work with libraries that are way too complicated for them, like
-`Pygame`, `Tkinter` or `discord.py` and whose usage require notions such as the 
+`Pygame`, `Tkinter` or `discord.py` and whose usage require notions such as 
 Object Oriented Programming, error handling, decorators or even manipulation of threads/async.
 
 If you do not know what a function or an object is, or can not manipulate `for` and `while` loops,

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -1,39 +1,39 @@
-# Starting off right with Python
+# Starting Off Right with Python
 
 Programming is a very interesting, lucrative and vast domain.
 Choosing Python as a first language is really often a judicious choice for many reasons.
 
 Here are some of them:
 - Python has a very simple syntax, that permits to get compact and readable codes ;
-- Python is very complete. Concretely, we can do a huge amount of things with it.
+- Python is very rich. Concretely, we can do a huge amount of things with it.
 From AI, to the Web backend, to its usage in scientific domains... the list goes on ;
 - The language has a huge community of developers with a lot of resources,
  and some of its functionalities make the learning process easier for beginners.
 One example is that the language does not enforce the usage of `;` after each instruction.
 
 
-### Some good resources to get started
+### Some Good Resources to get started
 
 > On the Internet, lots of tutorials/courses to learn development exist, except that many
-> of them are bad because they teach you bad obsolete practices. - [learndev.info](https://www.learndev.info/en)
+> of them are bad because they teach you bad or obsolete practices. - [learndev.info](https://www.learndev.info/en)
 
 
 In fact, the resources available on the Internet are not always relevant or up-to-date.
-As a solution to solve this issue [learndev.info](https://www.learndev.info/en) was created, aiming to offer adapted and relevant courses,
+As a solution to solve this issue, [learndev.info](https://www.learndev.info/en) was created, aiming to offer adapted and relevant courses,
 such as the course of **[ TODO ]**.
 
 
 
-### Mistakes not to do when you begin
+### Mistakes Not to Do When You Begin
 
 Many people begin programming with the idea that it is not necessarily complicated,
-and they can quickly start very big projects without the need to acquire the bases.
+thinking they can quickly start very big projects without the need to acquire the basics.
 Well, that is mostly a big mistake.
 
 In fact, when it comes to learning a language (whether it is Python or another), things need to be done carefully.
 You should not try to drive a car before learning to do it. And yet, unfortunately a lot of
-Python beginners get to work with libraries that are way too much complicated for them, like
-`Pygame`, `Tkinter` or such as `discord.py` and whose usage require notions such as the 
+Python beginners get to work with libraries that are way too complicated for them, like
+`Pygame`, `Tkinter` or `discord.py` and whose usage require notions such as the 
 Object Oriented Programming, error handling, decorators or even manipulation of threads/async.
 
 If you do not know what a function or an object is, or can not manipulate `for` and `while` loops,

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -24,7 +24,7 @@ such as the course of **[ TODO ]**.
 
 
 
-### What not to do when you begin
+### Errors to not do when you begin
 
 Many people begin programming with the idea that is not necessary complicated,
 and we can quickly make very big projects without the need to aquire all the bases.
@@ -32,13 +32,13 @@ Well, that is mostly a big mistake.
 
 In fact, learn a language whether it is Python or another, need to be done carefully.
 You should not try to drive a car without learn to do it. Thus, a lot of beginners 
-in Python launches themselves in libraries too much advanced for them, like `Pygame`, `Tkinter` or such as `discord.py`
+in Python launch themselves in libraries too much advanced for them, like `Pygame`, `Tkinter` or such as `discord.py`
 that need advanced notions such as the Oriented Object Programming, the error handling,
 decorators or even the manipulation of threads/async.
 
 If you do not know what is a function, an object or manipulate loops likes `for` and `while` loops,
-you have everything to gain to let your project on a side for a time to consolidate your knowledges and even, make
-projects at your scale in order to accumulate knowledges for the one that is close to your heart.
+you have everything to gain to let your project on a side for a time to consolidate your knowledge and even, make
+projects at your scale in order to accumulate knowledge for the one that is close to your heart.
 Do not be afraid to let a project during several months.
 Accumulate frustration by continuously failling on a too ambicious project can disgust you with
 programming in general (that would be counterproductive).

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -12,7 +12,7 @@ From AI, to the Web backend, to its usage in scientific domains... the list goes
 One example is that the language does not enforce the usage of `;` after each instruction.
 
 
-### Some Good Resources to get started
+### Some Good Resources to Get Started
 
 > On the Internet, lots of tutorials/courses to learn development exist, except that many
 > of them are bad because they teach you bad or obsolete practices. - [learndev.info](https://www.learndev.info/en)

--- a/python/starter_kit/en/START_WELL.md
+++ b/python/starter_kit/en/START_WELL.md
@@ -1,12 +1,12 @@
 # Starting well with Python
 
-Programming is a domain wery interesting, lucrative and vast.
+Programming is a domain very interesting, lucrative and vast.
 Begin with Python is really often a judicious choice for many reasons.
 
 Here are some of them:
 - Python has a very simple syntax, that permits to get compact and lisible codes ;
 - Python is very complete. Concretely, we can do a huge amount of things with it.
-From AI, throught the Web backend, to its utilisation in the scientific domains. ;
+From AI, throught the Web backend, to its utilization in the scientific domains ;
 - The language has a huge community of developers with a lot of resources,
  and some of its functionalities make learning easy for the beginners.
 (for some reasons hard to explain here, but for instance, the language does not enforce the usage of `;` after each expression).
@@ -34,19 +34,19 @@ In fact, learn a language whether it is Python or another, need to be done caref
 You should not try to drive a car without learn to do it. Thus, a lot of beginners 
 in Python launches themselves in libraries too much advanced for them, like `Pygame`, `Tkinter` or such as `discord.py`
 that need advanced notions such as the Oriented Object Programming, the error handling,
-decorators or even the mannipulation of threads/async.
+decorators or even the manipulation of threads/async.
 
-If you do not know what is a function, an object or manipulate loops likes `for` and  `while` loops,
-you have everything to gain to let your project on a side for the time to consolidate your knowledges and even make
+If you do not know what is a function, an object or manipulate loops likes `for` and `while` loops,
+you have everything to gain to let your project on a side for a time to consolidate your knowledges and even, make
 projects at your scale in order to accumulate knowledges for the one that is close to your heart.
-Do not be affraid to let a project during several monthes.
+Do not be afraid to let a project during several months.
 Accumulate frustration by continuously failling on a too ambicious project can disgust you with
-programming in genneral (that will be counterproductive).
+programming in general (that would be counterproductive).
 
 
 ### Projects, lots of projects, more projects!
 
-What is better to begin with programming more than give themself objectives. Have a project
+What is better to begin with programming more than give yourself objectives. Have a project
 is a very great way to learn. Indeed, after seeing the theory in courses,
 begin a project, permits to practice. Practicing is the only way that permits to remember durably.
 Thus, we can begin small and adapted projects to what we learn.
@@ -61,7 +61,7 @@ There are always things to learn, to experiment or to discover.
 
 ### Conclusion
 
-Python is a really good language to bgin in the programming world. Moreover to be easy to learn,
+Python is a really good language to begin in the programming world. Moreover to be easy to learn,
 it permits a huge amount of things. Dispite the fact, it is necessary to practice with the help of projects,
-it is very discouraged to begin with something too big for yourserf.
-Finally, if there is only one sentence to remember from that, it would be this one: "Do not stop to learn".
+it is very discouraged to begin with something too big for yourself.
+Finally, if there is only one sentence to remember from that, it would be this one: "Never stop learning".


### PR DESCRIPTION
Starting point for the English translation of `python/starter-kit`. 

There are still a few changes to be made, so is not ready to be merged.
Notably, a French course is recommended in the original version, if you want to replace it, I'm open to the suggestion.